### PR TITLE
Handle empty predefined string types when no `empty` rule

### DIFF
--- a/src/typeStrategies/email.js
+++ b/src/typeStrategies/email.js
@@ -3,7 +3,7 @@ const email = {
     default: /.+@.+\.\S+/
   },
   default: context => {
-    if (context.value === null || context.value && !context.value.toString().match(email._regex.default)) {
+    if (context.value == null || !context.value || !context.value.toString().match(email._regex.default)) {
       context.fail('Value must be a valid email')
     }
   }

--- a/src/typeStrategies/ip.js
+++ b/src/typeStrategies/ip.js
@@ -4,12 +4,12 @@ const ip = {
     v6: /^((?:[0-9A-Fa-f]{1,4}))((?::[0-9A-Fa-f]{1,4}))*::((?:[0-9A-Fa-f]{1,4}))((?::[0-9A-Fa-f]{1,4}))*|((?:[0-9A-Fa-f]{1,4}))((?::[0-9A-Fa-f]{1,4})){7}$/
   },
   v4: context => {
-    if (context.value === null || context.value && !context.value.toString().match(ip._regex.v4)) {
+    if (context.value == null || !context.value.length || !context.value.toString().match(ip._regex.v4)) {
       context.fail('Value must be a valid IPv4 address')
     }
   },
   v6: context => {
-    if (context.value === null || context.value && !context.value.toString().match(ip._regex.v6)) {
+    if (context.value == null || !context.value.length || !context.value.toString().match(ip._regex.v6)) {
       context.fail('Value must be a valid IPv6 address')
     }
   },

--- a/src/typeStrategies/phone.js
+++ b/src/typeStrategies/phone.js
@@ -4,12 +4,14 @@ const phone = {
     numeric: /\d{7,10}/
   },
   default: context => {
-    if (context.value === null || context.value && !context.value.toString().match(phone._regex.default)) {
+    const stringified = context.value != null && context.value.toString()
+    if (!stringified || !stringified.length || !stringified.toString().match(phone._regex.default)) {
       context.fail('Value must be a valid phone number')
     }
   },
   numeric: context => {
-    if (context.value === null || context.value && !context.value.toString().match(phone._regex.numeric)) {
+    const stringified = context.value != null && context.value.toString()
+    if (!stringified || !stringified.length || !stringified.toString().match(phone._regex.numeric)) {
       context.fail('Value must be a numeric phone number')
     }
   }

--- a/src/typeStrategies/string.js
+++ b/src/typeStrategies/string.js
@@ -8,7 +8,7 @@ const string = {
     }
   },
   alphanumeric: context => {
-    if (context.value === null || context.value && !context.value.toString().match(string._regex.alphanumeric)) {
+    if (context.value == null || !context.value.length || !context.value.toString().match(string._regex.alphanumeric)) {
       context.fail('Value must contain only letters and/or numbers')
     }
   }

--- a/src/typeStrategies/url.js
+++ b/src/typeStrategies/url.js
@@ -3,7 +3,7 @@ const url = {
     default: /^(?:https?:\/\/)?[^\s\/\.]+(?:\.[a-z0-9-]{2,})+(?:\/\S*)?$/i
   },
   default: context => {
-    if (context.value === null || context.value && !context.value.toString().match(url._regex.default)) {
+    if (context.value == null || !context.value.length || !context.value.toString().match(url._regex.default)) {
       context.fail('Value must be a valid URL')
     }
   }

--- a/src/typeStrategies/uuid.js
+++ b/src/typeStrategies/uuid.js
@@ -3,7 +3,7 @@ const uuid = {
     default: /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/
   },
   default: context => {
-    if (context.value === null || context.value && !context.value.toString().match(uuid._regex.default)) {
+    if (context.value == null || !context.value.length || !context.value.toString().match(uuid._regex.default)) {
       context.fail('Value must be a valid UUID')
     }
   }

--- a/src/typeStrategies/zip.js
+++ b/src/typeStrategies/zip.js
@@ -4,12 +4,12 @@ const zip = {
     ca: /^([A-Z][0-9][A-Z])\s*([0-9][A-Z][0-9])$/
   },
   default: context => {
-    if (context.value === null || context.value && !context.value.toString().match(zip._regex.default)) {
+    if (context.value == null || !context.value.length || !context.value.toString().match(zip._regex.default)) {
       context.fail('Value must be a valid US zip code')
     }
   },
   ca: context => {
-    if (context.value === null || context.value && !context.value.toString().match(zip._regex.ca)) {
+    if (context.value == null || !context.value.length || !context.value.toString().match(zip._regex.ca)) {
       context.fail('Value must be a valid Canadian zip code')
     }
   }

--- a/src/types.js
+++ b/src/types.js
@@ -54,8 +54,10 @@ const types = {
     if (def.empty && typeof value === 'string' && def.type !== 'array' && value.length === 0) {
       return value
     }
+    // Account for stray empties
+    const isEmptyOrUndefined = value === undefined || value === ''
     // Don't run if undefined on required
-    if (def.required && value === undefined && !def.opts.partial) {
+    if (def.required && isEmptyOrUndefined && !def.opts.partial) {
       errors.push({ type: 'required', sub: 'default', key, value, message: `Property '${key}' is required` })
       return value
     }

--- a/test/fixtures/core.js
+++ b/test/fixtures/core.js
@@ -47,5 +47,8 @@ module.exports = {
   },
   requiredPredefined: {
     zip: { type: 'zip', required: true }
+  },
+  notRequiredPredefined: {
+    phone: { type: 'phone' }
   }
 }

--- a/test/fixtures/core.js
+++ b/test/fixtures/core.js
@@ -44,5 +44,8 @@ module.exports = {
   conditionalWithCreator: {
     fname: { type: 'string', requiredIf: { lname: 'Bar' }, creator: 'foo-namer' },
     lname: { type: 'string' }
+  },
+  requiredPredefined: {
+    zip: { type: 'zip', required: true }
   }
 }

--- a/test/integration/core.spec.js
+++ b/test/integration/core.spec.js
@@ -204,12 +204,20 @@ describe('integration:core', () => {
           )
       })
   })
-  it('does not allow empty predefined type value without `empty` rule', () => {
+  it('does not allow empty predefined type value without `empty` rule when required', () => {
     const testModel = obey.model(modelFixtures.requiredPredefined)
     const testData = { zip: '' }
     return testModel.validate(testData)
       .catch(err => {
-        expect(err.message).to.equal('zip (): Value must be a valid US zip code')
+        expect(err.message).to.equal('zip (): Property \'zip\' is required')
+      })
+  })
+  it('does not allow empty predefined type value without `empty` rule when not required', () => {
+    const testModel = obey.model(modelFixtures.notRequiredPredefined)
+    const testData = { phone: '' }
+    return testModel.validate(testData)
+      .catch(err => {
+        expect(err.message).to.equal('phone (): Value must be a valid phone number')
       })
   })
 })

--- a/test/integration/core.spec.js
+++ b/test/integration/core.spec.js
@@ -204,4 +204,12 @@ describe('integration:core', () => {
           )
       })
   })
+  it('does not allow empty predefined type value without `empty` rule', () => {
+    const testModel = obey.model(modelFixtures.requiredPredefined)
+    const testData = { zip: '' }
+    return testModel.validate(testData)
+      .catch(err => {
+        expect(err.message).to.equal('zip (): Value must be a valid US zip code')
+      })
+  })
 })

--- a/test/src/typeStrategies/email.spec.js
+++ b/test/src/typeStrategies/email.spec.js
@@ -10,6 +10,14 @@ describe('type:email', () => {
     email.default(context)
     expect(context.fail).to.be.calledWith('Value must be a valid email')
   })
+  it('calls context.fail if value is empty', () => {
+    const context = {
+      value: '',
+      fail: sinon.spy()
+    }
+    email.default(context)
+    expect(context.fail).to.be.calledWith('Value must be a valid email')
+  })
   it('does not call context.fail if type is a valid email (standard)', () => {
     const context = {
       value: 'jsmith@gmail.com',

--- a/test/src/typeStrategies/ip.spec.js
+++ b/test/src/typeStrategies/ip.spec.js
@@ -10,6 +10,14 @@ describe('type:ip', () => {
     ip.v4(context)
     expect(context.fail).to.be.calledWith('Value must be a valid IPv4 address')
   })
+  it('calls context.fail if type is empty (ipv4)', () => {
+    const context = {
+      value: '',
+      fail: sinon.spy()
+    }
+    ip.v4(context)
+    expect(context.fail).to.be.calledWith('Value must be a valid IPv4 address')
+  })
   it('does not call context.fail if type is a valid ipv4', () => {
     const context = {
       value: '192.168.1.1',
@@ -21,6 +29,14 @@ describe('type:ip', () => {
   it('calls context.fail if type is not a valid ipv6', () => {
     const context = {
       value: 'foo',
+      fail: sinon.spy()
+    }
+    ip.v6(context)
+    expect(context.fail).to.be.calledWith('Value must be a valid IPv6 address')
+  })
+  it('calls context.fail if type is empty (ipv6)', () => {
+    const context = {
+      value: '',
       fail: sinon.spy()
     }
     ip.v6(context)

--- a/test/src/typeStrategies/phone.spec.js
+++ b/test/src/typeStrategies/phone.spec.js
@@ -10,6 +10,14 @@ describe('type:phone', () => {
     phone.default(context)
     expect(context.fail).to.be.calledWith('Value must be a valid phone number')
   })
+  it('calls context.fail if value is empty', () => {
+    const context = {
+      value: '',
+      fail: sinon.spy()
+    }
+    phone.default(context)
+    expect(context.fail).to.be.calledWith('Value must be a valid phone number')
+  })
   it('does not call context fail if value is a valid phone number', () => {
     // Variation
     const contextOne = { value: '(555)-123-4567', fail: sinon.spy() }
@@ -27,6 +35,14 @@ describe('type:phone', () => {
   it('calls context.fail if value is not a valid numeric phone number', () => {
     const context = {
       value: 'foo',
+      fail: sinon.spy()
+    }
+    phone.numeric(context)
+    expect(context.fail).to.be.calledWith('Value must be a numeric phone number')
+  })
+  it('calls context.fail if value is empty (numeric)', () => {
+    const context = {
+      value: '',
       fail: sinon.spy()
     }
     phone.numeric(context)

--- a/test/src/typeStrategies/url.spec.js
+++ b/test/src/typeStrategies/url.spec.js
@@ -10,6 +10,14 @@ describe('type:url', () => {
     url.default(context)
     expect(context.fail).to.be.calledWith('Value must be a valid URL')
   })
+  it('calls context.fail if type is empty', () => {
+    const context = {
+      value: '',
+      fail: sinon.spy()
+    }
+    url.default(context)
+    expect(context.fail).to.be.calledWith('Value must be a valid URL')
+  })
   it('does not call context.fail if type is a valid URL', () => {
     const context = {
       value: 'https://www.google.com/test',

--- a/test/src/typeStrategies/uuid.spec.js
+++ b/test/src/typeStrategies/uuid.spec.js
@@ -10,6 +10,14 @@ describe('type:uuid', () => {
     uuid.default(context)
     expect(context.fail).to.be.calledWith('Value must be a valid UUID')
   })
+  it('calls context.fail if type is empty', () => {
+    const context = {
+      value: '',
+      fail: sinon.spy()
+    }
+    uuid.default(context)
+    expect(context.fail).to.be.calledWith('Value must be a valid UUID')
+  })
   it('does not call context.fail if type is a valid UUID', () => {
     const context = {
       value: 'ef3d56e1-6046-4743-aa69-b94bc9e66181',

--- a/test/src/typeStrategies/zip.spec.js
+++ b/test/src/typeStrategies/zip.spec.js
@@ -10,6 +10,14 @@ describe('type:zip', () => {
     zip.default(context)
     expect(context.fail).to.be.calledWith('Value must be a valid US zip code')
   })
+  it('calls context.fail if value is empty (US)', () => {
+    const context = {
+      value: '',
+      fail: sinon.spy()
+    }
+    zip.default(context)
+    expect(context.fail).to.be.calledWith('Value must be a valid US zip code')
+  })
   it('does not call context fail if value is a valid zip code', () => {
     const context = {
       value: '61029',
@@ -21,6 +29,14 @@ describe('type:zip', () => {
   it('calls context.fail if value is not a valid CA zip code', () => {
     const context = {
       value: 'foo',
+      fail: sinon.spy()
+    }
+    zip.ca(context)
+    expect(context.fail).to.be.calledWith('Value must be a valid Canadian zip code')
+  })
+  it('calls context.fail if value is empty (CA)', () => {
+    const context = {
+      value: '',
       fail: sinon.spy()
     }
     zip.ca(context)


### PR DESCRIPTION
Fixes #76 