### PR TITLE
Stringify zip codes before validating

### DIFF
--- a/src/typeStrategies/zip.js
+++ b/src/typeStrategies/zip.js
@@ -4,12 +4,14 @@ const zip = {
     ca: /^([A-Z][0-9][A-Z])\s*([0-9][A-Z][0-9])$/
   },
   default: context => {
-    if (context.value == null || !context.value.length || !context.value.toString().match(zip._regex.default)) {
+    const stringified = context.value != null && context.value.toString()
+    if (!stringified || !stringified.length || !stringified.match(zip._regex.default)) {
       context.fail('Value must be a valid US zip code')
     }
   },
   ca: context => {
-    if (context.value == null || !context.value.length || !context.value.toString().match(zip._regex.ca)) {
+    const stringified = context.value != null && context.value.toString()
+    if (!stringified || !stringified.length || !stringified.match(zip._regex.ca)) {
       context.fail('Value must be a valid Canadian zip code')
     }
   }

--- a/test/src/typeStrategies/zip.spec.js
+++ b/test/src/typeStrategies/zip.spec.js
@@ -18,7 +18,15 @@ describe('type:zip', () => {
     zip.default(context)
     expect(context.fail).to.be.calledWith('Value must be a valid US zip code')
   })
-  it('does not call context fail if value is a valid zip code', () => {
+  it('does not call context fail if value is a valid zip code (numeric)', () => {
+    const context = {
+      value: 61029,
+      fail: sinon.spy()
+    }
+    zip.default(context)
+    expect(context.fail).to.not.be.called
+  })
+  it('does not call context fail if value is a valid zip code (string)', () => {
     const context = {
       value: '61029',
       fail: sinon.spy()


### PR DESCRIPTION
* Fixed bug in `zip` type that disallowed numeric values. Now values are coerced to strings before validation checks. 