### PR TITLE
Add Jexl plugin integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ When setting definitions for rules or model properties, the following are suppor
 * `allowNull`: Accepts a null value or processes specified type
 * `strict`: Enable or disable strict checking of an object, see [Strict Mode](#strict-mode)
 * `description`: A description of the property
+* `jexl`: One or more objects containing an `expr` string for validating data against Jexl expressions. See [Jexl Validation](#jexl-validation).
 
 ## Types
 
@@ -328,6 +329,49 @@ To disable strict mode on a model pass the (optional) strict argument as `false`
 
 ```javascript
 const model = obey.model({ /* definition */ }, false)
+```
+
+## Jexl Validation
+
+Obey allows for validating data against [Jexl](https://github.com/TomFrost/Jexl) expressions via the `jexl` rule:
+
+```javascript
+obey.model({
+  exprVal: {
+    type: 'string',
+    jexl: [{
+      expr: "value == root.testVal.nestedObjArray[.name == 'some specific name'].payload",
+      message: "Do not seek the treasure" // Optional expression-specific error message
+    }]
+  },
+  testVal: {
+    type: 'object',
+    keys: {
+      nestedObjArray: {
+        type: 'array',
+        values: {
+          type: 'object',
+          keys: {
+            name: { type: 'string' },
+            payload: { type: 'string' }
+          }
+        }
+      }
+    }
+  }
+})
+```
+
+**Note**: the `jexl` validator uses `value` and `root` as its context keys for the specific value being validated and the corresponding data, respectively, so expression strings should be constructed accordingly.
+
+If necessary, a preconfigured Jexl instance can be passed in before the model is constructed, in order to utitlize user-defined transforms in validation:
+
+```javascript
+const obey = require('obey')
+const jexl = require('jexl')
+jexl.addTransform('upper', val => val.toUpperCase(val))
+obey.use('jexl', jexl)
+obey.model({/* ...definition... */})
 ```
 
 ## Asynchronous Validation

--- a/package-lock.json
+++ b/package-lock.json
@@ -1945,6 +1945,11 @@
         }
       }
     },
+    "jexl": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/jexl/-/jexl-2.1.1.tgz",
+      "integrity": "sha512-a+dZiuYIKl0nPYdAe7sJ8D/bCAbemwLjLypcT2brXtft/Mi3titp1QRCpTkaHrp+qeno8DKFxVpVKYNvw1AV3A=="
+    },
     "js-tokens": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   "dependencies": {
     "bluebird": "^3.5.3",
     "dot-object": "^1.7.1",
+    "jexl": "^2.1.1",
     "lodash": "^4.17.11"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ const modifiers = require('./modifiers')
 const creators = require('./creators')
 const validators = require('./lib/validators')
 const ValidationError = require('./lib/error')
+const plugins = require('./lib/plugins')
 
 /**
  * The main object for Obey; exposes the core API methods for standard use as
@@ -59,5 +60,14 @@ module.exports = {
    * @param {string} name The creator's name
    * @param {function} fn The method for the creator
    */
-  creator: (name, fn) => creators.add(name, fn)
+  creator: (name, fn) => creators.add(name, fn),
+
+  /**
+   * Adds given package to plugins lib.
+   *
+   * @param {string} name The package name
+   * @param {function|Object} pkg The package reference
+   */
+  // TODO: make this actually useful
+  use: (name, pkg) => plugins.add(name, pkg)
 }

--- a/src/lib/plugins.js
+++ b/src/lib/plugins.js
@@ -1,0 +1,25 @@
+/**
+ * @namespace plugins
+ */
+const plugins = {
+  /**
+   * @memberof plugins
+   * @property {Object} Library of plugins
+   */
+  lib: {},
+  /**
+   * Adds a package to the library
+   * @memberof creators
+   * @param {string} name The name of the package
+   * @param {function|Object} fn The package reference
+   */
+  add: (name, pkg) => {
+    if (typeof name !== 'string') throw new Error('plugin name should be a string')
+    if (typeof pkg !== 'object' && typeof pkg !== 'function') {
+      throw new Error('plugin package should be an object or function')
+    }
+    plugins.lib[name] = pkg
+  }
+}
+
+module.exports = plugins

--- a/src/lib/validators.js
+++ b/src/lib/validators.js
@@ -176,15 +176,8 @@ const validators = {
     const type = 'jexl'
     const sub = Array.isArray(def.jexl) ? def.jexl : [ def.jexl ]
     const promises = sub.map(({expr, message = null}) => {
+      const instance = plugins.lib.jexl || jexl
       message = message || 'Value failed Jexl evaluation'
-
-      let instance = jexl
-      if (!plugins.lib.jexl) {
-        console.log('-----\nObey Warning: No Jexl plugin instance found\n-----')
-      } else {
-        instance = plugins.lib.jexl
-      }
-
       return instance.eval(expr, { root: data, value })
         .then(val => {
           if (!val) errors.push({ type, sub, key, value, message })

--- a/src/lib/validators.js
+++ b/src/lib/validators.js
@@ -175,15 +175,18 @@ const validators = {
   jexl: (def, value, key, errors, data) => {
     const type = 'jexl'
     const sub = Array.isArray(def.jexl) ? def.jexl : [ def.jexl ]
-    const promises = sub.map(({expr, message = null}) => {
+    const promises = sub.map((obj) => {
+      const {
+        expr,
+        message = 'Value failed Jexl evaluation'
+      } = obj
       const instance = plugins.lib.jexl || jexl
-      message = message || 'Value failed Jexl evaluation'
       return instance.eval(expr, { root: data, value })
         .then(val => {
-          if (!val) errors.push({ type, sub, key, value, message })
+          if (!val) errors.push({ type, sub: obj, key, value, message })
         })
         .catch(() => {
-          errors.push({ type, sub, key, value, message })
+          errors.push({ type, sub: obj, key, value, message })
         })
     })
     Promise.all(promises)

--- a/src/rules.js
+++ b/src/rules.js
@@ -25,7 +25,8 @@ const allProps = {
   requiredIfNot: { name: 'requiredIfNot', fn: validators.requiredIfNot },
   requireIf: { name: 'requireIf', fn: validators.requireIf },
   requireIfNot: { name: 'requireIfNot', fn: validators.requireIfNot },
-  equalTo: { name: 'equalTo', fn: validators.equalTo }
+  equalTo: { name: 'equalTo', fn: validators.equalTo },
+  jexl: { name: 'jexl', fn: validators.jexl }
 }
 
 /**
@@ -52,7 +53,8 @@ const rules = {
       allProps.requiredIfNot,
       allProps.requireIf,
       allProps.requireIfNot,
-      allProps.equalTo
+      allProps.equalTo,
+      allProps.jexl
     ],
     // No value/undefined
     noVal: [
@@ -63,7 +65,8 @@ const rules = {
       allProps.requiredIfNot,
       allProps.requireIf,
       allProps.requireIfNot,
-      allProps.equalTo
+      allProps.equalTo,
+      allProps.jexl
     ],
     // No value, partial
     noValPartial: []

--- a/test/fixtures/validators.js
+++ b/test/fixtures/validators.js
@@ -64,6 +64,32 @@ module.exports = {
       }
     }
   },
+  jexlMessage: {
+    exprVal: { type: 'string', jexl: [{
+      expr: "value == root.testVal.nestedObjArray[.name == 'theOne'].payload.treasure",
+      message: "Do not seek the treasure"
+    }] },
+    testVal: {
+      type: 'object',
+      keys: {
+        nestedObjArray: {
+          type: 'array',
+          values: {
+            type: 'object',
+            keys: {
+              name: { type: 'string' },
+              payload: {
+                type: 'object',
+                keys: {
+                  treasure: { type: 'string' }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
   jexlTransform: {
     exprVal: { type: 'string', jexl: [{
       expr: "value|upper == root.testVal.nestedObjArray[.name == 'theOne'].payload.treasure|upper"

--- a/test/fixtures/validators.js
+++ b/test/fixtures/validators.js
@@ -38,5 +38,55 @@ module.exports = {
       state: { type: 'string' },
       country: { type: 'string', requiredIfNot: 'address.state' }
     }}
+  },
+  jexl: {
+    exprVal: { type: 'string', jexl: [{
+      expr: "value == root.testVal.nestedObjArray[.name == 'theOne'].payload.treasure"
+    }] },
+    testVal: {
+      type: 'object',
+      keys: {
+        nestedObjArray: {
+          type: 'array',
+          values: {
+            type: 'object',
+            keys: {
+              name: { type: 'string' },
+              payload: {
+                type: 'object',
+                keys: {
+                  treasure: { type: 'string' }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  jexlTransform: {
+    exprVal: { type: 'string', jexl: [{
+      expr: "value|upper == root.testVal.nestedObjArray[.name == 'theOne'].payload.treasure|upper"
+    }] },
+    testVal: {
+      type: 'object',
+      keys: {
+        nestedObjArray: {
+          type: 'array',
+          values: {
+            type: 'object',
+            keys: {
+              name: { type: 'string' },
+              payload: {
+                type: 'object',
+                keys: {
+                  treasure: { type: 'string' }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
   }
 }

--- a/test/integration/validators.spec.js
+++ b/test/integration/validators.spec.js
@@ -168,9 +168,9 @@ describe('integration:validators', () => {
       return testModel.validate(testData).catch(err => {
         expect(err.collection).to.deep.equal([{
           type: 'jexl',
-          sub: [{
+          sub: {
             expr: "value == root.testVal.nestedObjArray[.name == 'theOne'].payload.treasure"
-          }],
+          },
           key: 'exprVal',
           value: 'Dapper Dan',
           message: 'Value failed Jexl evaluation'
@@ -194,10 +194,10 @@ describe('integration:validators', () => {
       return testModel.validate(testData).catch(err => {
         expect(err.collection).to.deep.equal([{
           type: 'jexl',
-          sub: [{
+          sub: {
             expr: "value == root.testVal.nestedObjArray[.name == 'theOne'].payload.treasure",
             message: 'Do not seek the treasure'
-          }],
+          },
           key: 'exprVal',
           value: 'Dapper Dan',
           message: 'Do not seek the treasure'

--- a/test/integration/validators.spec.js
+++ b/test/integration/validators.spec.js
@@ -132,7 +132,7 @@ describe('integration:validators', () => {
       })
     })
   })
-  describe('jexlValidations', () => {
+  describe('jexl', () => {
     it('builds a models and validates based on jexl expression', () => {
       const testModel = obey.model(modelFixtures.jexl)
       const testData = {
@@ -167,7 +167,7 @@ describe('integration:validators', () => {
       }
       return testModel.validate(testData).catch(err => {
         expect(err.collection).to.deep.equal([{
-          type: 'jexlValidations',
+          type: 'jexl',
           sub: [{
             expr: "value == root.testVal.nestedObjArray[.name == 'theOne'].payload.treasure"
           }],

--- a/test/integration/validators.spec.js
+++ b/test/integration/validators.spec.js
@@ -177,6 +177,33 @@ describe('integration:validators', () => {
         }])
       })
     })
+    it('builds a models and fails with custom message', () => {
+      const testModel = obey.model(modelFixtures.jexlMessage)
+      const testData = {
+        exprVal: 'Dapper Dan',
+        testVal: {
+          nestedObjArray: [
+            { name: 'wrong' },
+            {
+              name: 'theOne',
+              payload: { treasure: 'Fop' }
+            }
+          ]
+        }
+      }
+      return testModel.validate(testData).catch(err => {
+        expect(err.collection).to.deep.equal([{
+          type: 'jexl',
+          sub: [{
+            expr: "value == root.testVal.nestedObjArray[.name == 'theOne'].payload.treasure",
+            message: 'Do not seek the treasure'
+          }],
+          key: 'exprVal',
+          value: 'Dapper Dan',
+          message: 'Do not seek the treasure'
+        }])
+      })
+    })
     it('builds a models and validates using jexl plugin instance', () => {
       const jexl = require('jexl')
       jexl.addTransform('upper', (val) => val.toUpperCase())

--- a/test/integration/validators.spec.js
+++ b/test/integration/validators.spec.js
@@ -132,4 +132,71 @@ describe('integration:validators', () => {
       })
     })
   })
+  describe('jexlValidations', () => {
+    it('builds a models and validates based on jexl expression', () => {
+      const testModel = obey.model(modelFixtures.jexl)
+      const testData = {
+        exprVal: 'Dapper Dan',
+        testVal: {
+          nestedObjArray: [
+            { name: 'wrong' },
+            {
+              name: 'theOne',
+              payload: { treasure: 'Dapper Dan' }
+            }
+          ]
+        }
+      }
+      return testModel.validate(testData).then(res => {
+        expect(res).to.deep.equal(testData)
+      })
+    })
+    it('builds a models and fails validation based on jexl expression', () => {
+      const testModel = obey.model(modelFixtures.jexl)
+      const testData = {
+        exprVal: 'Dapper Dan',
+        testVal: {
+          nestedObjArray: [
+            { name: 'wrong' },
+            {
+              name: 'theOne',
+              payload: { treasure: 'Fop' }
+            }
+          ]
+        }
+      }
+      return testModel.validate(testData).catch(err => {
+        expect(err.collection).to.deep.equal([{
+          type: 'jexlValidations',
+          sub: [{
+            expr: "value == root.testVal.nestedObjArray[.name == 'theOne'].payload.treasure"
+          }],
+          key: 'exprVal',
+          value: 'Dapper Dan',
+          message: 'Value failed Jexl evaluation'
+        }])
+      })
+    })
+    it('builds a models and validates using jexl plugin instance', () => {
+      const jexl = require('jexl')
+      jexl.addTransform('upper', (val) => val.toUpperCase())
+      obey.use('jexl', jexl)
+      const testModel = obey.model(modelFixtures.jexlTransform)
+      const testData = {
+        exprVal: 'Dapper Dan',
+        testVal: {
+          nestedObjArray: [
+            { name: 'wrong' },
+            {
+              name: 'theOne',
+              payload: { treasure: 'Dapper Dan' }
+            }
+          ]
+        }
+      }
+      return testModel.validate(testData).then(res => {
+        expect(res).to.deep.equal(testData)
+      })
+    })
+  })
 })


### PR DESCRIPTION
* Added `jexl` validator method for evaluating data against [Jexl](https://github.com/TomFrost/Jexl) expressions.

* Added root `use` method for adding plugin references to external packages. (Currently only used by `jexl` validator.)