### PR TITLE
Fix/allow empty

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -5,5 +5,9 @@ ignore:
     - jsdoc > marked:
         reason: Dev Dependecy
         expires: '2016-05-28T00:25:33.252Z'
+  SNYK-JS-LODASH-450202:
+    - lodash:
+        reason: None given
+        expires: '2019-08-03T20:58:36.052Z'
 patch: {}
-version: v1.7.1
+version: v1.13.5

--- a/src/lib/validators.js
+++ b/src/lib/validators.js
@@ -31,9 +31,8 @@ const validators = {
     const type = 'allow'
     const sub = typeof def.allow === 'object' && !Array.isArray(def.allow) ? Object.keys(def.allow) : def.allow
     const subIsArray = Array.isArray(sub)
-    if (subIsArray && sub.indexOf(value) === -1) {
-      errors.push({ type, sub, key, value, message: `Value '${value}' is not allowed` })
-    } else if (!subIsArray && sub !== value) {
+    if ((subIsArray && sub.indexOf(value) === -1) || (!subIsArray && sub !== value)) {
+      if (value === '' && def.empty) return
       errors.push({ type, sub, key, value, message: `Value '${value}' is not allowed` })
     }
   },

--- a/test/fixtures/core.js
+++ b/test/fixtures/core.js
@@ -50,5 +50,11 @@ module.exports = {
   },
   notRequiredPredefined: {
     phone: { type: 'phone' }
+  },
+  allowEmptyString: {
+    foo: { type: 'string', allow: [ 'bar' ], empty: true }
+  },
+  allowEmptyStringObject: {
+    foo: { type: 'string', allow: { foo: 'FOO' }, empty: true }
   }
 }

--- a/test/integration/core.spec.js
+++ b/test/integration/core.spec.js
@@ -220,4 +220,20 @@ describe('integration:core', () => {
         expect(err.message).to.equal('phone (): Value must be a valid phone number')
       })
   })
+  it('builds a model correctly with `allow` (object) and `empty` rules', () => {
+    const testModel = obey.model(modelFixtures.allowEmptyStringObject)
+    const testData = { foo: '' }
+    return testModel.validate(testData)
+      .then(res => {
+        expect(res).to.deep.equal(testData)
+      })
+  })
+  it('builds a model correctly with `allow` and `empty` rules', () => {
+    const testModel = obey.model(modelFixtures.allowEmptyString)
+    const testData = { foo: '' }
+    return testModel.validate(testData)
+      .then(res => {
+        expect(res).to.deep.equal(testData)
+      })
+  })
 })


### PR DESCRIPTION
Closes #83 

* Fixed bug around `allow` stomping on `empty` when validating strings. Originally using `allow` would require specifying `''` as an allowed value, even if `empty` was also enabled.